### PR TITLE
Re-enable root login via password

### DIFF
--- a/initrd-build.sh
+++ b/initrd-build.sh
@@ -23,6 +23,9 @@ do_secret_clean() {
     for target in $BUILDROOT/etc/{group,passwd,shadow} ; do
         run_command sed -i -r -e "/${core}|${udev}/!d" "$target"
     done
+
+    # Re-enable root login via password for initramfs only
+    run_command sed -i -r -e 's/(^root:)!(.*)/\1\2/' $BUILDROOT/etc/shadow
 }
 
 # ensure dropbear server host keys


### PR DESCRIPTION
"root" login via password should be disabled by default on production systems for security reasons.

In the case of a headless system which rootfs is password encrypted, for example using LVM on LUKS, the user will need to login via SSH to give the LUKS password in order to resume the boot sequence. Since opening a LUKS container requires "root" privileges, the user will have to get these one way or another. Logging in directly as "root" using keys is then a good option.

Keys however come with their own constraints and challenges (think: management) and in the case of a system for which you will still have to give a password to unlock the LUKS container, they might be overkill. In that corner case, logging in as "root" with a password (enabled ONLY for the initramfs) becomes an acceptable solution.